### PR TITLE
Fix locale value

### DIFF
--- a/src/main/fulcro_template/server.clj
+++ b/src/main/fulcro_template/server.clj
@@ -110,7 +110,7 @@
           uri         (:uri req)
           bidi-match  (bidi/match-route routing/app-routes uri) ; where they were trying to go. NOTE: This is shared code with the client!
           valid-page? (boolean bidi-match)
-          language    (some-> req :headers (get "accept-language") (str/split #",") first keyword)]
+          language    (some-> req :headers (get "accept-language") (str/split #",") first)]
 
       ; . no valid bidi match. BYPASS. We don't handle it.
       (if valid-page?


### PR DESCRIPTION
A new `string?` assertion introduced in https://github.com/fulcrologic/fulcro/commit/d025516779d4551fa390b9706309c8d0a57293c5#diff-78c37ee756ab1e41a8fbb9c61ec91c12R99 made this version of the template break.