### PR TITLE
Update README: add figwheel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NOTE: Due to popular demand I've created a bare-bones Leiningen template for Fulcro (as of September 2017). I mentioned
 on the defn podcast that I didn't have one, but I've since decided it is useful enough to maintain. So, you can
-now run `lein new fulcro your-new-app` to get something smaller that still
+now run `lein new fulcro your-new-app` (use the `figwheel` option if you don't want to use `shadow-cljs`) to get something smaller that still
 has support for development, production, devcards, and testing.
 
 This is a full stack sample application with specs, dev cards, and client code.


### PR DESCRIPTION
I had a hard time understanding why `lein new fulcro demo` wasn't generating script/figwheel.clj (and I didn't saw the warning on the terminal :shrug:). So I got to this repo and it was saying to simply use `lein new fulcro demo` I just understood what was going on when I read this [README](https://github.com/fulcrologic/fulcro-lein-template)